### PR TITLE
Support SegWit transactions

### DIFF
--- a/Sources/BitcoinBlockchain/BitcoinBlockchain.csproj
+++ b/Sources/BitcoinBlockchain/BitcoinBlockchain.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Data\Witness.cs" />
     <Compile Include="Parser\ByteArrayExtension.cs" />
     <Compile Include="Parser\BinaryReaderExtension.cs" />
     <Compile Include="Data\BlockchainFile.cs" />
@@ -75,7 +76,6 @@
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProgramFiles)\MSBuild\StyleCop\v4.7\StyleCop.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Sources/BitcoinBlockchain/Data/Transaction.cs
+++ b/Sources/BitcoinBlockchain/Data/Transaction.cs
@@ -27,15 +27,22 @@ namespace BitcoinBlockchain.Data
         private readonly List<TransactionOutput> transactionOutputs;
 
         /// <summary>
+        /// Witness data, one for each txin
+        /// </summary>
+        private readonly List<Witness> transactionWitness;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Transaction" /> class.
         /// </summary>
         public Transaction()
         {
             this.transactionInputs = new List<TransactionInput>();
             this.transactionOutputs = new List<TransactionOutput>();
+            this.transactionWitness = new List<Witness>();
 
             this.Inputs = new ReadOnlyCollection<TransactionInput>(this.transactionInputs);
             this.Outputs = new ReadOnlyCollection<TransactionOutput>(this.transactionOutputs);
+            this.Witness = new ReadOnlyCollection<Witness>(this.transactionWitness);
         }
 
         /// <summary>
@@ -71,6 +78,16 @@ namespace BitcoinBlockchain.Data
         public ReadOnlyCollection<TransactionOutput> Outputs { get; private set; }
 
         /// <summary>
+        /// Gets the read-only collection witness data
+        /// </summary>
+        public ReadOnlyCollection<Witness> Witness { get; private set; }
+
+        /// <summary>
+        /// Gets if the transaction has any any witness data (SegWit)
+        /// </summary>
+        public bool HasWitnessData { get { return transactionWitness.Count != 0; } }
+
+        /// <summary>
         /// Adds a new input to the list of transaction inputs.
         /// </summary>
         /// <param name="transactionInput">
@@ -79,6 +96,18 @@ namespace BitcoinBlockchain.Data
         public void AddInput(TransactionInput transactionInput)
         {
             this.transactionInputs.Add(transactionInput);
+        }
+
+        /// <summary>
+        /// Adds witness data to the list of transaction witnesses
+        /// There should be one Witness object for each txin
+        /// </summary>
+        /// <param name="witness">
+        /// The witness that should be added to the list of witnesses.
+        /// </param>
+        public void AddWitness(Witness witness)
+        {
+            this.transactionWitness.Add(witness);
         }
 
         /// <summary>

--- a/Sources/BitcoinBlockchain/Data/Witness.cs
+++ b/Sources/BitcoinBlockchain/Data/Witness.cs
@@ -1,0 +1,23 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Witness.cs">
+// Copyright © Jeffrey Quesnelle. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace BitcoinBlockchain.Data
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Contains witness data for transaction inputs. Currently the witness data itself is unparsed
+    /// For more information see:
+    /// <c>https://bitcoincore.org/en/segwit_wallet_dev/</c>
+    /// </summary>
+    public class Witness
+    {
+        /// <summary>
+        /// Witness data stack
+        /// </summary>
+        public List<ByteArray> WitnessStack { get; set; }
+    }
+}

--- a/Sources/BitcoinBlockchain/Parser/BlockchainParser.cs
+++ b/Sources/BitcoinBlockchain/Parser/BlockchainParser.cs
@@ -150,14 +150,16 @@ namespace BitcoinBlockchain.Parser
 
             blockHeader.BlockVersion = blockMemoryStreamReader.ReadUInt32();
 
-            //// TODO: We need to understand better what is different in V2 and V3.
-
-            if (   blockHeader.BlockVersion               != 1 &&                                  // original version
-                   blockHeader.BlockVersion               != 2 && blockHeader.BlockVersion != 3 && // used by BIP 34/65/66
-                 ((blockHeader.BlockVersion & 0xE0000000) != 0x20000000)                           // BIP 9 signaling
-               )
-            { 
-                throw new UnknownBlockVersionException(string.Format(CultureInfo.InvariantCulture, "Unknown block version: {0} ({0:X}).", blockHeader.BlockVersion));
+            switch (blockHeader.BlockVersion)
+            {
+                case 1: case 2: case 3: case 4: // original block version and BIP 34/65/66
+                    break;
+                default: 
+                    if ((blockHeader.BlockVersion & 0xE0000000) != 0x20000000 && // BIP 9 signaling
+                        (blockHeader.BlockVersion & 0x08000000) != 0x08000000    // BitPay adaptive block size HF signaling
+                       ) 
+                        throw new UnknownBlockVersionException(string.Format(CultureInfo.InvariantCulture, "Unknown block version: {0} ({0:X}).", blockHeader.BlockVersion));
+                    break;
             }
 
             blockHeader.PreviousBlockHash = new ByteArray(blockMemoryStreamReader.ReadBytes(32).ReverseByteArray());


### PR DESCRIPTION
This pull request adds support for the new extended SegWit transaction format. The new structure can be seen in the Bitcoin source code [here](https://github.com/bitcoin/bitcoin/blob/892809309c1bc370677241a715e57a2744f94323/src/primitives/transaction.h#L186).

In addition, this pull changes how block version numbers are handled. Previously, all known version combinations were explicitly white-listed. The version field has been somewhat re-purposed by [BIP 9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) for soft/hard fork signaling. I've changed the version code to handle this, so every bit combination won't need to be explicitly be checked for.

One housekeeping note: I've removed the StyleCop reference from the project since I don't have this.

I used this branch to fully process the Bitcoin blockchain with [BitcoinDatabaseGenerator](https://github.com/ladimolnar/BitcoinDatabaseGenerator)